### PR TITLE
Setup GitHub Actions to work

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,13 +6,12 @@ jobs:
   check:
     name: RSpec
     runs-on: ubuntu-latest
-    container: circleci/ruby:2.7.3-buster-node-browsers
     steps:
-      # @see https://docs.github.com/actions/reference/virtual-environments-for-github-hosted-runners#docker-container-filesystem
-      - name: Setup file system permissions
-        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
       - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: gem install bundler:2.2.3 && bundle install --path vendor/bundle
-      - run: bundle exec rspec --format documentation
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.2
+          bundler-cache: true
+      - uses: browser-actions/setup-chrome@latest
+      - run: CHROME_EXECUTABLE_PATH=$(which chrome) bundle exec rspec --format documentation
         timeout-minutes: 45

--- a/lib/capybara/puppeteer/node.rb
+++ b/lib/capybara/puppeteer/node.rb
@@ -758,27 +758,21 @@ module Capybara
           @source.scroll_into_view_if_needed
 
           # down
-          position_from = center_of(@source)
-          @page.mouse.move(*position_from)
+          position_from = @source.clickable_point
+          @page.mouse.move(position_from.x, position_from.y)
           @page.mouse.down
 
           @target.scroll_into_view_if_needed
 
           # move and up
           sleep_delay
-          position_to = center_of(@target)
+          position_to = @target.clickable_point
           with_key_pressing(drop_modifiers) do
-            @page.mouse.move(*position_to, steps: 6)
+            @page.mouse.move(position_to.x, position_to.y, steps: 6)
             sleep_delay
             @page.mouse.up
           end
           sleep_delay
-        end
-
-        # @param element [Puppeteer::ElementHandle]
-        private def center_of(element)
-          box = element.bounding_box
-          [box.x + box.width / 2, box.y + box.height / 2]
         end
 
         private def with_key_pressing(keys, &block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,15 @@ RSpec.configure do |config|
 end
 
 Capybara.register_driver(:puppeteer) do |app|
-  Capybara::Puppeteer::Driver.new(app, headless: ENV['CI'] ? true : false)
+  driver_options = {}
+  if ENV['CI']
+    driver_options[:headless] = true
+    driver_options[:executable_path] = ENV['CHROME_EXECUTABLE_PATH']
+  else
+    driver_options[:headless] = false
+  end
+  driver_options.compact!
+  Capybara::Puppeteer::Driver.new(app, **driver_options)
 end
 
 Capybara.default_driver = :puppeteer


### PR DESCRIPTION
No reason to use circleci Docker images any more. Just use [browser-actions/setup-chrome](https://github.com/browser-actions/setup-chrome).