### PR TITLE
fix find method

### DIFF
--- a/lib/capybara/puppeteer/browser.rb
+++ b/lib/capybara/puppeteer/browser.rb
@@ -66,10 +66,6 @@ module Capybara
       end
 
       def find_css(query, **options)
-        if query.start_with?('//')
-          return find_xpath(query, **options)
-        end
-
         assert_page_alive
 
         find_with(:query_selector_all, query, **options)

--- a/spec/feature/find_spec.rb
+++ b/spec/feature/find_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe 'find' do
+  before {
+    visit 'about:blank'
+    execute_script('document.write("<h1>It works!</h1><input type=\"text\" name=\"q\" id=\"input_text\" />")')
+  }
+
+  it 'can find by id' do
+    node = find('#input_text')
+    expect(node['id']).to eq('input_text')
+  end
+
+  it 'can find by CSS selector' do
+    node = find('input[name="q"]')
+    expect(node['id']).to eq('input_text')
+  end
+
+  it 'can find by XPath query' do
+    node = find(:xpath, '//input[@name="q"]')
+    expect(node['id']).to eq('input_text')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,13 @@ RSpec.configure do |config|
   config.around(:each, type: :capybara) do |example|
     Timeout.timeout(15) { example.run }
   end
+
+  config.around(:each, type: :feature) do |example|
+    default_selector = Capybara.default_selector
+    Capybara.default_selector = :css
+    example.run
+    Capybara.default_selector = default_selector
+  end
 end
 
 Capybara.register_driver(:puppeteer) do |app|


### PR DESCRIPTION
Capybara don't auto-detect CSS selector or XPath query, and just use Capybara.default_selector for `find(xxx)`

Capybara.default_selector is set to :xpath on reset_sessions!
https://github.com/teamcapybara/capybara/blob/090bebf3a0ed3758220c435566c2716495ba11ae/lib/capybara/spec/spec_helper.rb#L25

No workaround logic is needed for find_css.